### PR TITLE
super() does contain an obj argument

### DIFF
--- a/datapunt_api/serializers.py
+++ b/datapunt_api/serializers.py
@@ -19,7 +19,7 @@ def get_links(view_name, kwargs=None, request=None):
 
 class DataSetSerializerMixin(object):
     def to_representation(self, obj):
-        result = super(obj).to_representation(obj)
+        result = super().to_representation(obj)
         result['dataset'] = self.dataset
         return result
 


### PR DESCRIPTION
Got an error with fixing the tellus api with DRF:
`TypeError: super() argument 1 must be type, not classobj`
Solved this error by looking at the earlier code:
https://github.com/Amsterdam/nap_meetbouten/blob/master/nap_meetbouten/datapunt_generic/generic/rest.py#L25
Is this true and does this not break anything?