### PR TITLE
Replaced staticfiles with static

### DIFF
--- a/datapunt_api/templates/rest_framework/api.html
+++ b/datapunt_api/templates/rest_framework/api.html
@@ -1,6 +1,6 @@
 {% extends "rest_framework/base.html" %}
 
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Datapunt: Atlas API{% endblock %}
 


### PR DESCRIPTION
The templates in datapunt_api use {% load staticfiles %} inside
the templates. That has been deprecated since 2.1, and removed in 3.0.

Error:
django.template.exceptions.TemplateSyntaxError:
'staticfiles' is not a registered tag library.