### PR TITLE
Fix docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM amsterdam/python
+FROM python:3.11-slim
 
-RUN apt-get install -y spatialite-bin libsqlite3-mod-spatialite
+RUN set -eux; \
+    apt-get update -yqq; \
+    apt-get install -y \
+      spatialite-bin \
+      libsqlite3-mod-spatialite \
+      gdal-bin
+
 COPY . /app/
-RUN pip install -r /app/requirements.txt
 
 WORKDIR /app/
+
+RUN pip install --upgrade -r requirements.txt -r requirements_dev.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,6 @@ version: '3.0'
 services:
 
   tests:
-    build: .
-    environment:
-      DATABASE_NAME: test
-      DATABASE_USER: test
-      DATABASE_PASSWORD: insecure
-      ENVIRONMENT: test
-    command: make test
+    image: drf_amsterdam_test
+    build:
+      context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,5 @@ services:
     image: drf_amsterdam_test
     build:
       context: .
+    volumes:
+      - .:/app


### PR DESCRIPTION
This PR upgrades the `Dockerfile` so that it uses the official python image instead of the unmaintained `amsterdam/python` image and modifies the `docker-compose.yml` file so we can use it for development and running the tests.