### PR TITLE
Fix deprecation warnings and sort queryset ordering in views and settings for tests

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -184,7 +184,7 @@ class SerializerTest(TestCase):
     def test_display_field(self):
         ws = WeatherStation.objects.get(number__exact=260)
         serializer = DisplayFieldSerializer(ws)
-        self.assertEquals(
+        self.assertEqual(
             serializer.data['_display'],
             'DISPLAY FIELD CONTENT'
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 SECRET_KEY = 'fake-key'
+USE_TZ = False
 INSTALLED_APPS = [
     'django_filters',
     'datapunt_api',

--- a/tests/views.py
+++ b/tests/views.py
@@ -71,15 +71,15 @@ class TemperatureRecordViewSet(DatapuntViewSet): # noqa
 
 
 class SimpleViewSet(ReadOnlyModelViewSet):
+    queryset = SimpleModel.objects.all().order_by('id')
     serializer_class = SelfLinksSerializer
-    queryset = SimpleModel.objects.all()
 
 
 class ThingViewSet(ReadOnlyModelViewSet):
-    queryset = Thing.objects.all()
+    queryset = Thing.objects.all().order_by('id')
     serializer_class = ThingSerializer
 
 
 class PersonViewSet(ReadOnlyModelViewSet):
-    queryset = Person.objects.all()
+    queryset = Person.objects.all().order_by('id')
     serializer_class = PersonSerializer


### PR DESCRIPTION
Fix deprecation warnings and sort queryset ordering in views and settings for tests.