### PR TITLE
Explicitly define workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,8 @@ on:
   schedule:
     # 12:30 UTC is at 8:30 or 9:30 EST depending on DST
     - cron: '30 12 * * *'
-
+permissions:
+  contents: read
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
See security tab above. We should explicitly define workflow permissions as the default permissions might change in the future leaving us in a vulnerable position.